### PR TITLE
Add CI and tests for Ubuntu installation script

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,20 @@
+name: Test for Ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    env:
+      WPT_SERVER: "www.webpagetest.org"
+      WPT_LOCATION: Tokyo
+      DISABLE_IPV6: y
+      WPT_KEY: foobar
+      # for msodbcsql17 package
+      ACCEPT_EULA: Y
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./ubuntu.sh
+      - name: test
+        run: chmod +x ./.github/workflows/test.sh && ./.github/workflows/test.sh

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Check if packages are installed
+dpkg --status git > /dev/null
+dpkg --status screen > /dev/null
+dpkg --status watchdog > /dev/null
+dpkg --status curl > /dev/null
+dpkg --status wget > /dev/null
+dpkg --status apt-transport-https > /dev/null
+dpkg --status xserver-xorg-video-dummy > /dev/null
+
+test -f "${HOME}/startup.sh"
+test -f "${HOME}/agent.sh"
+
+test "$(cat /etc/systemd/journald.conf | grep "SystemMaxUse=1M")" == "SystemMaxUse=1M"
+test "$(cat /etc/watchdog.conf | grep "test-binary = $HOME/wptagent/alive.sh")" == "test-binary = $HOME/wptagent/alive.sh"
+
+sudo sysctl --load
+
+test "$(sysctl vm.panic_on_oom)" == "vm.panic_on_oom = 1"
+test "$(sysctl kernel.panic)" == "kernel.panic = 10"

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set -eu
+
+# Assign empty string if not defined
+: ${DISABLE_IPV6:=''}
+: ${WPT_SERVER:=''}
+: ${WPT_LOCATION:=''}
+: ${WPT_KEY:=''}
+
 # Prompt for the configuration options
 echo "Automatic agent install and configuration."
 echo

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -3,7 +3,12 @@
 # Prompt for the configuration options
 echo "Automatic agent install and configuration."
 echo
-read -e -p "Disable IPv6 (recommended unless IPv6 connectivity is available) (Y/n): " -i "y" DISABLE_IPV6
+
+while [[ $DISABLE_IPV6 == '' ]]
+do
+  read -e -p "Disable IPv6 (recommended unless IPv6 connectivity is available) (Y/n): " -i "y" DISABLE_IPV6
+done
+
 while [[ $WPT_SERVER == '' ]]
 do
   read -p "WebPageTest server (i.e. www.webpagetest.org): " WPT_SERVER
@@ -12,7 +17,11 @@ while [[ $WPT_LOCATION == '' ]]
 do
   read -p "Location ID (i.e. Dulles): " WPT_LOCATION
 done
-read -p "Location Key (if required): " WPT_KEY
+while [[ $WPT_KEY == '' ]]
+do
+  read -p "Location Key (if required): " WPT_KEY
+done
+
 
 # Pre-prompt for the sudo authorization so it doesn't prompt later
 sudo date


### PR DESCRIPTION
This PR adds tests for Ubuntu version of this installation script.

Since only ubuntu.sh can be tested on free CI services (AFAIK), I only add the test for Ubuntu this time.