### PR TITLE
Make --machine-type configuable in gce_image.sh

### DIFF
--- a/gce_image.sh
+++ b/gce_image.sh
@@ -12,9 +12,20 @@ while [[ "$INSTANCE_METADATA" == "" ]]
 do
     read -p "Instance Metadata String (wpt_server=...): " INSTANCE_METADATA
 done
+
+if [[ "$MACHINE_TYPE" == "" ]]
+then
+    DEFAULT_MACHINE_TYPE=n1-standard-2
+    read -p "Machine type (see https://cloud.google.com/compute/docs/machine-types) [${DEFAULT_MACHINE_TYPE}]: " MACHINE_TYPE
+    if [[ "$MACHINE_TYPE" == "" ]]
+    then
+        MACHINE_TYPE="${DEFAULT_MACHINE_TYPE}"
+    fi
+fi
+
 ESCAPED_METADATA=$(printf %q "$INSTANCE_METADATA")
 
-COMMAND="gcloud compute --project=${DEVSHELL_PROJECT_ID} instance-templates create ${TEMPLATE_NAME} --machine-type=n1-standard-2 --network=projects/${DEVSHELL_PROJECT_ID}/global/networks/default --metadata=wpt_data=${ESCAPED_METADATA} --no-restart-on-failure --maintenance-policy=TERMINATE --preemptible --min-cpu-platform=Automatic --image=wpt-linux-20200127 --image-project=webpagetest-official --boot-disk-size=10GB --boot-disk-type=pd-standard --boot-disk-device-name=${TEMPLATE_NAME}"
+COMMAND="gcloud compute --project=${DEVSHELL_PROJECT_ID} instance-templates create ${TEMPLATE_NAME} --machine-type=${MACHINE_TYPE} --network=projects/${DEVSHELL_PROJECT_ID}/global/networks/default --metadata=wpt_data=${ESCAPED_METADATA} --no-restart-on-failure --maintenance-policy=TERMINATE --preemptible --min-cpu-platform=Automatic --image=wpt-linux-20200127 --image-project=webpagetest-official --boot-disk-size=10GB --boot-disk-type=pd-standard --boot-disk-device-name=${TEMPLATE_NAME}"
 echo $COMMAND
 eval $COMMAND
 


### PR DESCRIPTION
In an install script for GCP, `gce_iamge.sh`, the machine type is fixed to `n1-standard-2`, but I suspect the machine power is not enough to get correct results, so I'd like use more powerful machines. This PR allows us to select the machine type in installation. The default does not change.