### PR TITLE
update apt and ca-certificates in agents to fix WPO-Foundation/webpagetest#1563

### DIFF
--- a/debian.sh
+++ b/debian.sh
@@ -470,6 +470,8 @@ if [ "${WPT_INTERACTIVE,,}" == 'n' ]; then
 # build the startup script
 echo '#!/bin/sh' > ~/startup.sh
 echo "PATH=$PWD/bin:$PWD/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" >> ~/startup.sh
+echo 'sudo DEBIAN_FRONTEND=noninteractive apt update -yq' >> ~/startup.sh
+echo 'sudo DEBIAN_FRONTEND=noninteractive apt install ca-certificates -yq' >> ~/startup.sh
 echo 'cd ~' >> ~/startup.sh
 echo 'if [ -e first.run ]' >> ~/startup.sh
 echo 'then' >> ~/startup.sh
@@ -491,6 +493,10 @@ if [ "${WPT_INTERACTIVE,,}" == 'n' ]; then
 echo '#!/bin/sh' > ~/firstrun.sh
 echo 'cd ~' >> ~/firstrun.sh
 echo 'until sudo apt -y update' >> ~/firstrun.sh
+echo 'do' >> ~/firstrun.sh
+echo '    sleep 1' >> ~/firstrun.sh
+echo 'done' >> ~/firstrun.sh
+echo 'until sudo DEBIAN_FRONTEND=noninteractive apt install ca-certificates -yq' >> ~/firstrun.sh
 echo 'do' >> ~/firstrun.sh
 echo '    sleep 1' >> ~/firstrun.sh
 echo 'done' >> ~/firstrun.sh


### PR DESCRIPTION
fixes node installation ssl certificate issue

fixes WPO-Foundation/webpagetest#1563, details about root cause can be found in https://github.com/nodesource/distributions/issues/1266  and https://techcrunch.com/2021/09/21/lets-encrypt-root-expiry/