### PR TITLE
Add support for installing on Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ WPT_SERVER="webpagetest.mycompany.com" WPT_LOCATION="Dulles" WPT_KEY="xxxSomeSec
 ```
 
 ## Ubuntu 18.04+:
-Tested on 18.04 LTS and 20.04 LTS
+Tested on 18.04 LTS, 20.04 LTS, and 22.04 LTS
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/WPO-Foundation/wptagent-install/master/debian.sh)
@@ -89,7 +89,7 @@ bash <(curl -s https://raw.githubusercontent.com/WPO-Foundation/wptagent-install
   * Add ~/wptagent-install/macos/Agent and Watchdog
 * Reboot
 
-## Dev Setup on Ubuntu Desktop (18.04 LTS recommended)
+## Dev Setup on Ubuntu Desktop (22.04 LTS recommended)
 Will not configure X, watchdog, cron or a startup script.  There will be a master branch checkout in ~/wptagent/ and a script to run the agent at ~/agent.sh
 
 ```bash

--- a/debian.sh
+++ b/debian.sh
@@ -172,13 +172,6 @@ else
     done
 fi
 
-# ImageMagick
-#git clone https://github.com/SoftCreatR/imei
-#cd imei
-#chmod +x imei.sh
-#sudo ./imei.sh
-#cd ~
-
 # Lighthouse
 until sudo npm install -g lighthouse
 do

--- a/debian.sh
+++ b/debian.sh
@@ -351,8 +351,8 @@ if [ "${AGENT_MODE,,}" == 'desktop' ]; then
                 sleep 1
             done
             wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz
-            rm geckodriver-v0.32.0-linux64.tar.gz
             tar xvzf geckodriver-v0.32.0-linux64.tar.gz
+            rm geckodriver-v0.32.0-linux64.tar.gz
             sudo mv geckodriver /usr/bin
         fi
 

--- a/debian.sh
+++ b/debian.sh
@@ -91,7 +91,7 @@ do
 done
 
 # Disable the ubuntu 22.04 prompt for restarting services
-echo "\$nrconf{restart} = 'a'" | sudo tee -a "/etc/needrestart/needrestart.conf"
+echo "\$nrconf{restart} = 'a'" | sudo tee -a "/etc/needrestart/needrestart.conf" ||:
 
 # system config
 if [ "${WPT_INTERACTIVE,,}" == 'y' ]; then
@@ -335,10 +335,10 @@ if [ "${AGENT_MODE,,}" == 'desktop' ]; then
         if [ "${WPT_FIREFOX,,}" == 'y' ]; then
             sudo add-apt-repository -y ppa:ubuntu-mozilla-daily/ppa
             sudo add-apt-repository -y ppa:mozillateam/ppa
-            echo 'Package: *' | sudo tee "/etc/apt/preferences.d/mozilla-firefox"
-            echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox"
-            echo 'Pin-Priority: 1001' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox"
-            echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";' | sudo tee "/etc/apt/apt.conf.d/51unattended-upgrades-firefox"
+            echo 'Package: *' | sudo tee "/etc/apt/preferences.d/mozilla-firefox" ||:
+            echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox" ||:
+            echo 'Pin-Priority: 1001' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox" ||:
+            echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";' | sudo tee "/etc/apt/apt.conf.d/51unattended-upgrades-firefox" ||:
             until sudo apt -y update
             do
                 sleep 1

--- a/debian.sh
+++ b/debian.sh
@@ -90,6 +90,9 @@ do
     sleep 1
 done
 
+# Disable the ubuntu 22.04 prompt for restarting services
+sudo echo "\$nrconf{restart} = 'a'" >> /etc/needrestart/needrestart.conf
+
 # system config
 if [ "${WPT_INTERACTIVE,,}" == 'y' ]; then
     until sudo apt -y install git curl wget apt-transport-https gnupg2

--- a/debian.sh
+++ b/debian.sh
@@ -138,7 +138,7 @@ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 # Agent dependencies
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 until sudo apt -y install python3 python3-pip python3-ujson \
-        dbus-x11 traceroute software-properties-common psmisc libnss3-tools iproute2 net-tools openvpn \
+        imagemagick dbus-x11 traceroute software-properties-common psmisc libnss3-tools iproute2 net-tools openvpn \
         libtiff5-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
         python3-dev libavutil-dev libmp3lame-dev libx264-dev yasm autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev \
         libtool libvorbis-dev pkg-config texi2html libtext-unidecode-perl python3-numpy python3-scipy perl \
@@ -170,11 +170,11 @@ else
 fi
 
 # ImageMagick
-git clone https://github.com/SoftCreatR/imei
-cd imei
-chmod +x imei.sh
-sudo ./imei.sh
-cd ~
+#git clone https://github.com/SoftCreatR/imei
+#cd imei
+#chmod +x imei.sh
+#sudo ./imei.sh
+#cd ~
 
 # Lighthouse
 until sudo npm install -g lighthouse

--- a/debian.sh
+++ b/debian.sh
@@ -138,7 +138,7 @@ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 # Agent dependencies
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 until sudo apt -y install python3 python3-pip python3-ujson \
-        imagemagick dbus-x11 traceroute software-properties-common psmisc libnss3-tools iproute2 net-tools openvpn \
+        dbus-x11 traceroute software-properties-common psmisc libnss3-tools iproute2 net-tools openvpn \
         libtiff5-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
         python3-dev libavutil-dev libmp3lame-dev libx264-dev yasm autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev \
         libtool libvorbis-dev pkg-config texi2html libtext-unidecode-perl python3-numpy python3-scipy perl \
@@ -168,6 +168,13 @@ else
         sleep 1
     done
 fi
+
+# ImageMagick
+git clone https://github.com/SoftCreatR/imei
+cd imei
+chmod +x imei.sh
+sudo ./imei.sh
+cd ~
 
 # Lighthouse
 until sudo npm install -g lighthouse

--- a/debian.sh
+++ b/debian.sh
@@ -343,10 +343,14 @@ if [ "${AGENT_MODE,,}" == 'desktop' ]; then
             do
                 sleep 1
             done
-            until sudo apt -yq install firefox firefox-trunk firefox-esr firefox-geckodriver
+            until sudo apt -yq install firefox firefox-trunk firefox-esr
             do
                 sleep 1
             done
+            wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz
+            rm geckodriver-v0.32.0-linux64.tar.gz
+            tar xvzf geckodriver-v0.32.0-linux64.tar.gz
+            sudo mv geckodriver /usr/bin
         fi
 
         if [ "${WPT_BRAVE,,}" == 'y' ]; then

--- a/debian.sh
+++ b/debian.sh
@@ -342,6 +342,10 @@ if [ "${AGENT_MODE,,}" == 'desktop' ]; then
         if [ "${WPT_FIREFOX,,}" == 'y' ]; then
             sudo add-apt-repository -y ppa:ubuntu-mozilla-daily/ppa
             sudo add-apt-repository -y ppa:mozillateam/ppa
+            echo 'Package: *' | sudo tee "/etc/apt/preferences.d/mozilla-firefox"
+            echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox"
+            echo 'Pin-Priority: 1001' | sudo tee -a "/etc/apt/preferences.d/mozilla-firefox"
+            echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";' | sudo tee "/etc/apt/apt.conf.d/51unattended-upgrades-firefox"
             until sudo apt -y update
             do
                 sleep 1

--- a/debian.sh
+++ b/debian.sh
@@ -91,7 +91,7 @@ do
 done
 
 # Disable the ubuntu 22.04 prompt for restarting services
-sudo echo "\$nrconf{restart} = 'a'" >> /etc/needrestart/needrestart.conf
+echo "\$nrconf{restart} = 'a'" | sudo tee -a "/etc/needrestart/needrestart.conf"
 
 # system config
 if [ "${WPT_INTERACTIVE,,}" == 'y' ]; then


### PR DESCRIPTION
Tested on server and desktop and back-tested on 18.04 to make sure nothing breaks there.  There are only 2 notable changes:

1. The needsrestart config at the beginning configures apt to automatically restart services as needed.  Otherwise it prompts for user input.
2. The Firefox install has to be forced to use apt instead of snap and geckodriver needs to be installed directly from the github releases instead of from apt.